### PR TITLE
fix most left column

### DIFF
--- a/boards/shields/corny/corny_left.overlay
+++ b/boards/shields/corny/corny_left.overlay
@@ -8,7 +8,7 @@
 		, <&gpio0 29 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
 		;
 	col-gpios
-		= <&gpio0 16 GPIO_ACTIVE_HIGH>   //Col0
+		= <&gpio0 10 GPIO_ACTIVE_HIGH>   //Col0
 		, <&gpio1 15 GPIO_ACTIVE_HIGH>   //Col1
 		, <&gpio1 14 GPIO_ACTIVE_HIGH>   //Col2
 		, <&gpio1 13 GPIO_ACTIVE_HIGH>   //Col3


### PR DESCRIPTION
Correct GPIO pin mapping for left column of Corny keyboard (left-hand side)

The leftmost column on the left-hand side of the Corny keyboard did not work.

I have updated the pin assignment to match the correctly functioning right-hand side, which fixed the issue.

These keys were not used in the current keymap. 
I am creating this PR in case it ever changes or for others who might fork this repository.

By the way, thank you for making it public!